### PR TITLE
fix bugs

### DIFF
--- a/networks/nvp_simplified.py
+++ b/networks/nvp_simplified.py
@@ -11,7 +11,8 @@ class CouplingLayer(nn.Module):
         super().__init__()
         self.map_st = map_st
         self.projection = projection
-        self.mask = mask
+        # self.mask = mask
+        self.register_buffer("mask", mask) ## register_buffer to save in state_dict
 
     def forward(self, F, y):
         y1 = y * self.mask


### PR DESCRIPTION
`mask` must be registered as buffer.
if not，when the random seeds are changed,  We cannot reproduce  results by loading ckpts. 
@qianqianwang68 